### PR TITLE
fix applying_sign to be also applicable to int

### DIFF
--- a/src/data/arithm.rs
+++ b/src/data/arithm.rs
@@ -473,7 +473,7 @@ impl Number {
                 if !self.is_positive() ^ sign.into() {
                     if self.count_ones() == 1 && !self.is_positive() {
                         // attempt to negate the minimum possible value for its layout
-                        return None
+                        return None;
                     }
                     let mut one = Number::from(1u8);
                     one.reshape(layout);
@@ -484,7 +484,7 @@ impl Number {
             }
             Layout::Integer(IntLayout { signed: false, .. }) => {
                 // applied to unsigned integer layout
-                return None
+                return None;
             }
             Layout::Float(..) => {
                 let sign_byte = layout.sign_byte();
@@ -662,5 +662,4 @@ mod tests {
         let y = Number::from(128i16);
         assert_eq!(x.abs().unwrap(), y);
     }
-
 }

--- a/src/data/arithm.rs
+++ b/src/data/arithm.rs
@@ -461,9 +461,10 @@ impl Number {
     /// Adds or removes negative sign to the number (negates negative or positive number, depending
     /// on the method argument value)
     ///
-    /// Returns None if:
+    /// # Returns
+    /// Result of the operation as an optional - or `None` if the operation was impossible, specifically:
     ///  - applied to unsigned integer layout
-    ///  - attempted to negate the minimum possible value for its layout (e.g. -128 as 1 byte)
+    ///  - an attempt to negate the minimum possible value for its layout (e.g. -128 as 1 byte)
     #[inline]
     pub fn applying_sign(mut self, sign: impl Into<bool>) -> Option<Number> {
         let layout = self.layout();

--- a/src/data/number.rs
+++ b/src/data/number.rs
@@ -679,7 +679,7 @@ impl Number {
     pub fn is_zero(self) -> bool {
         let mut clean = self.to_clean();
         if self.layout.is_float() {
-            clean = clean.without_sign();
+            clean = clean.without_sign().expect("should not fail when it is float");
         }
         clean.to_u1024_bytes() == u1024::from(0u8)
     }
@@ -802,23 +802,6 @@ impl Number {
             (from, to) => todo!("Number layout reshape from {} to {}", from, to),
         }
     }
-
-    /// Adds or removes negative sign to the number (negates negative or positive number, depending
-    /// on the method argument value)
-    #[inline]
-    pub fn applying_sign(mut self, sign: impl Into<bool>) -> Number {
-        let sign_byte = self.layout.sign_byte();
-        if sign.into() {
-            self[sign_byte] |= 0x80;
-        } else {
-            self[sign_byte] &= 0x7F;
-        }
-        self
-    }
-
-    /// Removes negative sign if present (negates negative number)
-    #[inline]
-    pub fn without_sign(self) -> Number { self.applying_sign(false) }
 
     #[doc(hidden)]
     /// Converts the value into `u1024` integer with the bytes corresponding to the internal

--- a/src/isa/exec.rs
+++ b/src/isa/exec.rs
@@ -409,7 +409,9 @@ impl InstructionSet for ArithmeticOp {
 
     fn exec(&self, regs: &mut CoreRegs, _: LibSite) -> ExecStep {
         let is_some = match self {
-            ArithmeticOp::Abs(reg, idx) => regs.set(reg, idx, regs.get(reg, idx).and_then(Number::abs)),
+            ArithmeticOp::Abs(reg, idx) => {
+                regs.set(reg, idx, regs.get(reg, idx).and_then(Number::abs))
+            }
             ArithmeticOp::AddA(flags, reg, src, srcdst) => {
                 let res = regs
                     .get_both(reg, src, reg, srcdst)
@@ -479,7 +481,7 @@ impl InstructionSet for ArithmeticOp {
             ),
             ArithmeticOp::Neg(reg, idx) => {
                 regs.set(reg, idx, regs.get(reg, idx).and_then(Number::neg))
-            },
+            }
         };
         regs.st0 = is_some;
         ExecStep::Next

--- a/src/isa/exec.rs
+++ b/src/isa/exec.rs
@@ -409,7 +409,7 @@ impl InstructionSet for ArithmeticOp {
 
     fn exec(&self, regs: &mut CoreRegs, _: LibSite) -> ExecStep {
         let is_some = match self {
-            ArithmeticOp::Abs(reg, idx) => regs.set(reg, idx, regs.get(reg, idx).map(Number::abs)),
+            ArithmeticOp::Abs(reg, idx) => regs.set(reg, idx, regs.get(reg, idx).and_then(Number::abs)),
             ArithmeticOp::AddA(flags, reg, src, srcdst) => {
                 let res = regs
                     .get_both(reg, src, reg, srcdst)
@@ -477,7 +477,9 @@ impl InstructionSet for ArithmeticOp {
                     }
                 }),
             ),
-            ArithmeticOp::Neg(reg, idx) => regs.set(reg, idx, regs.get(reg, idx).map(Number::neg)),
+            ArithmeticOp::Neg(reg, idx) => {
+                regs.set(reg, idx, regs.get(reg, idx).and_then(Number::neg))
+            },
         };
         regs.st0 = is_some;
         ExecStep::Next


### PR DESCRIPTION
Closes https://github.com/internet2-org/rust-aluvm/issues/33

prior to this change, `applying_sign`, `without_sign`, `neg` was only applicable to float numbers.