### PR TITLE
fix(BytesOp::Extr): set st0 to false when bit size of the destination plus the offset exceeds string length

### DIFF
--- a/src/isa/exec.rs
+++ b/src/isa/exec.rs
@@ -669,8 +669,11 @@ impl InstructionSet for BytesOp {
                 let mut f = || -> Option<()> {
                     let s = regs.get_s(*src)?.clone();
                     let offset = regs.a16[*offset as u8 as usize]?;
-                    let end = offset.saturating_add(dst.layout().bytes());
-                    let num = Number::from_slice(&s.as_ref()[offset as usize..=end as usize]);
+                    let end = offset.checked_add(dst.layout().bytes()).unwrap_or_else(|| {
+                        regs.st0 = false;
+                        u16::MAX
+                    });
+                    let num = Number::from_slice(&s.as_ref()[offset as usize..end as usize]);
                     regs.set(dst, index, num);
                     Some(())
                 };
@@ -910,7 +913,8 @@ impl InstructionSet for ReservedOp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::data::Step;
+    use crate::data::{Layout, Step};
+    use crate::reg::Reg16;
 
     #[test]
     fn cmp_ne_test() {
@@ -968,5 +972,90 @@ mod tests {
         CmpOp::EqA(NoneEqFlag::NonEqual, RegA::A8, Reg32::Reg1, Reg32::Reg2)
             .exec(&mut register, lib_site);
         assert_eq!(true, register.st0);
+    }
+
+    #[test]
+    fn bytes_put_test() {
+        let mut register = CoreRegs::default();
+        let lib_site = LibSite::default();
+        BytesOp::Put(1.into(), Box::new(ByteStr::with([1; u16::MAX as usize])), false)
+            .exec(&mut register, lib_site);
+        BytesOp::Put(2.into(), Box::new(ByteStr::with([1; u16::MAX as usize])), false)
+            .exec(&mut register, lib_site);
+        BytesOp::Put(3.into(), Box::new(ByteStr::with([2; u16::MAX as usize])), false)
+            .exec(&mut register, lib_site);
+        assert_eq!(true, register.st0);
+        BytesOp::Eq(1.into(), 2.into()).exec(&mut register, lib_site);
+        assert_eq!(true, register.st0);
+        BytesOp::Eq(1.into(), 3.into()).exec(&mut register, lib_site);
+        assert_eq!(false, register.st0);
+        ControlFlowOp::Succ.exec(&mut register, lib_site);
+        assert_eq!(true, register.st0);
+        BytesOp::Put(3.into(), Box::new(ByteStr::with([2; u16::MAX as usize])), true)
+            .exec(&mut register, lib_site);
+        assert_eq!(false, register.st0);
+    }
+
+    #[test]
+    fn bytes_extr_test() {
+        let mut register = CoreRegs::default();
+        let lib_site = LibSite::default();
+        let mut bytes = [0; u16::MAX as usize];
+        let offset = 5;
+        let s = "hello";
+        for (i, e) in s.as_bytes().iter().enumerate() {
+            bytes[offset + i] = *e;
+        }
+        BytesOp::Put(1.into(), Box::new(ByteStr::with(bytes)), false).exec(&mut register, lib_site);
+        PutOp::PutA(RegA::A16, Reg32::Reg1, MaybeNumber::from(offset as u16).into())
+            .exec(&mut register, lib_site);
+        BytesOp::Extr(1.into(), RegR::R128, Reg16::Reg1, Reg16::Reg1).exec(&mut register, lib_site);
+        let mut num = register.get(RegR::R128, Reg16::Reg1).unwrap();
+        num.reshape(Layout::unsigned(s.len() as u16));
+        assert_eq!(num, Number::from_slice(s.as_bytes()));
+        PutOp::PutA(RegA::A16, Reg32::Reg2, MaybeNumber::from(offset as u16 + 1).into())
+            .exec(&mut register, lib_site);
+        BytesOp::Extr(1.into(), RegR::R128, Reg16::Reg2, Reg16::Reg2).exec(&mut register, lib_site);
+        let mut num = register.get(RegR::R128, Reg16::Reg2).unwrap();
+        num.reshape(Layout::unsigned(s.len() as u16 - 1));
+        assert_eq!(num, Number::from_slice("ello".as_bytes()));
+        assert_eq!(true, register.st0);
+    }
+
+    #[test]
+    fn bytes_extr_offset_overflow_test() {
+        let mut register = CoreRegs::default();
+        let lib_site = LibSite::default();
+        let mut bytes = [0; u16::MAX as usize];
+        let offset = u16::MAX - 1;
+        bytes[offset as usize] = 7;
+        BytesOp::Put(1.into(), Box::new(ByteStr::with(bytes)), false).exec(&mut register, lib_site);
+        PutOp::PutA(RegA::A16, Reg32::Reg1, MaybeNumber::from(offset).into())
+            .exec(&mut register, lib_site);
+        BytesOp::Extr(1.into(), RegR::R128, Reg16::Reg1, Reg16::Reg1).exec(&mut register, lib_site);
+        assert_eq!(register.get(RegR::R128, Reg16::Reg1).unwrap(), Number::from(0x07u128));
+        assert_eq!(false, register.st0);
+    }
+
+    #[test]
+    fn bytes_extr_uninitialized_regr_test() {
+        let mut register = CoreRegs::default();
+        let lib_site = LibSite::default();
+        let bytes = [0; u16::MAX as usize];
+        BytesOp::Put(1.into(), Box::new(ByteStr::with(bytes)), false).exec(&mut register, lib_site);
+        BytesOp::Extr(1.into(), RegR::R128, Reg16::Reg1, Reg16::Reg1).exec(&mut register, lib_site);
+        assert_eq!(register.get(RegR::R128, Reg16::Reg1), MaybeNumber::none());
+        assert_eq!(false, register.st0);
+    }
+
+    #[test]
+    fn bytes_extr_uninitialized_bytes_test() {
+        let mut register = CoreRegs::default();
+        let lib_site = LibSite::default();
+        PutOp::PutA(RegA::A16, Reg32::Reg1, MaybeNumber::from(1).into())
+            .exec(&mut register, lib_site);
+        BytesOp::Extr(1.into(), RegR::R128, Reg16::Reg1, Reg16::Reg1).exec(&mut register, lib_site);
+        assert_eq!(register.get(RegR::R128, Reg16::Reg1), MaybeNumber::none());
+        assert_eq!(false, register.st0);
     }
 }


### PR DESCRIPTION
Current implementation is silent on offset overflow, while [docstring](https://github.com/internet2-org/rust-aluvm/blob/fc00a25e1dd55824bd89716e28be297a5945c0ab/src/isa/instr.rs#L683) says `If the bit size of the destination plus the initial offset exceeds string length the rest of the destination register bits is filled with zeros and st0 is set to false`.